### PR TITLE
Made value type of the messages a template parameter

### DIFF
--- a/include/boost/simulation/convenience.hpp
+++ b/include/boost/simulation/convenience.hpp
@@ -47,7 +47,7 @@ std::shared_ptr<pdevs::atomic<typename MODEL::time_type, typename MODEL::message
 
 //create a shared pointer to a hardware port
 template<class MODEL, typename... Args>
-std::shared_ptr<pdevs::port<typename MODEL::time_type, typename MODEL::message_type>> make_port_ptr(Args... args) noexcept {
+std::shared_ptr<pdevs::port<typename MODEL::time_type, typename MODEL::message_type, typename MODEL::value_type>> make_port_ptr(Args... args) noexcept {
     return std::make_shared<MODEL>(std::forward<Args>(args)...);
 }
 

--- a/include/boost/simulation/pdevs/driver.hpp
+++ b/include/boost/simulation/pdevs/driver.hpp
@@ -39,7 +39,7 @@ namespace pdevs {
 /**
  * @brief The coupled class represents PDEVS coupled models
  */
-template<class TIME, class MSG>
+template<class TIME, class MSG, class VALUE>
 class driver
 {
 protected:
@@ -49,8 +49,8 @@ protected:
 	int numberInputPorts;
 	std::vector<TIME> previousEventTime;
     struct topports_description{
-        std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> input_ports; //port to model
-        std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> output_ports; // model to port
+        std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> input_ports; //port to model
+        std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> output_ports; // model to port
     };
 
     topports_description _ports_desc;
@@ -58,14 +58,14 @@ public:
     using time_type=TIME;
     using message_type=MSG;
     using description_type=topports_description;
-    using Value=int;
+    using value_type=VALUE;
 
 
     /**
      * @brief driver receives the whole port structure by pointers to ports
      */
-    driver( std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> ip,
-		     std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> op
+    driver( std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> ip,
+		     std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> op
           ) noexcept
     {
         _ports_desc.input_ports = ip;
@@ -84,14 +84,14 @@ public:
     }
 
     bool get_hardware_event(MSG& input_message){
-        Value portValue;
+		value_type portValue;
         std::shared_ptr<model<TIME>> to_model;
-        std::shared_ptr<port<TIME,MSG>> current_port;
+        std::shared_ptr<port<TIME,MSG,VALUE>> current_port;
 
 
         bool foundEvent = false;
     	for (auto& ip : _ports_desc.input_ports){
-    	    current_port = std::dynamic_pointer_cast<port<TIME, MSG>>(ip.first);
+    	    current_port = std::dynamic_pointer_cast<port<TIME,MSG,VALUE>>(ip.first);
 
     	    int portIndex = &ip - &_ports_desc.input_ports[0]; // pos contains the position in the vector
 
@@ -127,7 +127,7 @@ public:
     	// SWO_PrintString("DRIVER: OUTPUT MESSAGE \n");
 		output_message.print();
 
-    	Value portValue = output_message.val;
+		value_type portValue = output_message.val;
     	for(auto& op : _ports_desc.output_ports){
     		if(op.first->asString() == port_name){
     			op.first->pDriver(portValue);

--- a/include/boost/simulation/pdevs/driver.hpp
+++ b/include/boost/simulation/pdevs/driver.hpp
@@ -39,7 +39,7 @@ namespace pdevs {
 /**
  * @brief The coupled class represents PDEVS coupled models
  */
-template<class TIME, class MSG, class VALUE>
+template<class TIME, class MSG, class VALUE=int>
 class driver
 {
 protected:

--- a/include/boost/simulation/pdevs/erunner.hpp
+++ b/include/boost/simulation/pdevs/erunner.hpp
@@ -49,7 +49,7 @@ namespace pdevs {
  * conditions, the ending conditions and the loggers, then it runs the simulation and
  * displays the results.
  */
-template <class TIME, class MSG, class VALUE, template<class, class> class FEL=nullqueue>
+template <class TIME, class MSG, template<class, class> class FEL=nullqueue, class VALUE=int>
 class erunner
 {
     TIME _next; //next scheduled event

--- a/include/boost/simulation/pdevs/erunner.hpp
+++ b/include/boost/simulation/pdevs/erunner.hpp
@@ -49,7 +49,7 @@ namespace pdevs {
  * conditions, the ending conditions and the loggers, then it runs the simulation and
  * displays the results.
  */
-template <class TIME, class MSG, template<class, class> class FEL=nullqueue, class VALUE=int>
+template <class TIME, class MSG, class VALUE=int>
 class erunner
 {
     TIME _next; //next scheduled event

--- a/include/boost/simulation/pdevs/erunner.hpp
+++ b/include/boost/simulation/pdevs/erunner.hpp
@@ -49,14 +49,14 @@ namespace pdevs {
  * conditions, the ending conditions and the loggers, then it runs the simulation and
  * displays the results.
  */
-template <class TIME, class MSG, template<class, class> class FEL=nullqueue>
+template <class TIME, class MSG, class VALUE, template<class, class> class FEL=nullqueue>
 class erunner
 {
     TIME _next; //next scheduled event
     std::shared_ptr<coordinator<TIME, MSG, nullqueue>> _coordinator; //ecoordinator of the top level coupled model.
-    std::shared_ptr<driver<TIME, MSG>> _driver; // global driver to manage top ports connected to hardware
-    std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> _input_ports;
-    std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> _output_ports;
+    std::shared_ptr<driver<TIME, MSG, VALUE>> _driver; // global driver to manage top ports connected to hardware
+    std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> _input_ports;
+    std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> _output_ports;
     bool _silent;
 
     void process_output(TIME t, std::vector<MSG>& m) noexcept {
@@ -85,12 +85,12 @@ public:
      */
 
 	 explicit erunner(std::shared_ptr<coupled<TIME, MSG>> cm,
-				std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> ip,
-				std::vector<std::pair<std::shared_ptr<port<TIME,MSG>>, std::shared_ptr<model<TIME>>>> op) noexcept
+				std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> ip,
+				std::vector<std::pair<std::shared_ptr<port<TIME,MSG,VALUE>>, std::shared_ptr<model<TIME>>>> op) noexcept
 	:    _input_ports(ip), _output_ports(op),infinity(cm->infinity)
     {
         for ( auto& inpport : ip){
-            std::shared_ptr<port<TIME, MSG>> in_p = std::dynamic_pointer_cast<port<TIME, MSG>>(inpport.first);
+            std::shared_ptr<port<TIME, MSG, VALUE>> in_p = std::dynamic_pointer_cast<port<TIME, MSG, VALUE>>(inpport.first);
             if ( in_p == nullptr){ //no input port provided
                printf("NULL PTR TO INPUT PORT \n");
              }
@@ -99,7 +99,7 @@ public:
         }
 
         for ( auto& outpport : op){
-            std::shared_ptr<port<TIME, MSG>> out_p = std::dynamic_pointer_cast<port<TIME, MSG>>(outpport.first);
+            std::shared_ptr<port<TIME, MSG, VALUE>> out_p = std::dynamic_pointer_cast<port<TIME, MSG, VALUE>>(outpport.first);
             if ( out_p == nullptr){ //no output port provided
                printf("NULL PTR TO OUTPUT PORT \n");
              }
@@ -107,7 +107,7 @@ public:
             	out_p->print();
         }
         _coordinator.reset(new coordinator<TIME, MSG, nullqueue>{cm});
-        _driver.reset(new driver<TIME,MSG>{ip,op});
+        _driver.reset(new driver<TIME,MSG, VALUE>{ip,op});
         _next = _coordinator->init(TIME(00,00,00,010)); //TIME::currentTime()
         _silent = false;
     }

--- a/include/boost/simulation/pdevs/port.hpp
+++ b/include/boost/simulation/pdevs/port.hpp
@@ -42,14 +42,14 @@ namespace pdevs {
  * during execution.
  */
 
-template <class TIME, class MSG>
+template <class TIME, class MSG, class VALUE>
 class port : public model<TIME>
 {
 public:
     using time_type=TIME;
     using message_type=MSG; //Message suggested for embedded execution is eMessage
-    using model_type=port<TIME, MSG>;
-    using Value=int;
+    using model_type=port<TIME, MSG, VALUE>;
+    using value_type=VALUE;
 
     port(const std::string &name) noexcept :portName( name ), pollingPeriod( TIME(0) ) {}
     port(const std::string &name, const TIME &pollingP) noexcept :portName( name ), pollingPeriod( pollingP ) {}
@@ -57,7 +57,7 @@ public:
     /**
      * @brief pDriver converts received signals into hardware commands or vice-versa - To be implemented by the user
      */
-    virtual bool pDriver(Value&) const noexcept = 0;
+    virtual bool pDriver(value_type&) const noexcept = 0;
     /**
      * @brief asString returns the name of the port
      */

--- a/include/boost/simulation/pdevs/port.hpp
+++ b/include/boost/simulation/pdevs/port.hpp
@@ -42,7 +42,7 @@ namespace pdevs {
  * during execution.
  */
 
-template <class TIME, class MSG, class VALUE>
+template <class TIME, class MSG, class VALUE=int>
 class port : public model<TIME>
 {
 public:


### PR DESCRIPTION
Now the values of the messages sent can be of any type (it use to be hardcoded for ints). I had to set the VALUE template parameter on ports, driver and erunner classes. The template parameter default was set to int for retrocompatibility.

Also I removed the template parameter FEL from erunner because it was unused.